### PR TITLE
Initializing queue objects in Brim constructor

### DIFF
--- a/src/GraphIO/Brim.cpp
+++ b/src/GraphIO/Brim.cpp
@@ -42,7 +42,9 @@ namespace graph {
 template<typename vid_t, typename eoff_t, typename weight_t>
 Brim<vid_t, eoff_t, weight_t>
 ::Brim(const GraphWeight<vid_t, eoff_t, weight_t>& graph) noexcept :
-                                            _graph(graph) {
+                                            _graph(graph),
+                                            _queue(_graph.nV()),
+                                            _in_queue(_graph.nV()) {
     _potentials = new potential_t[_graph.nV()];
     _counters   = new potential_t[_graph.nV()];
     reset();


### PR DESCRIPTION
This initializes the _queue and _in_queue objects in the CPU GraphIO Brim implementation.

This was tested by running brim on a graph input that results in the player 1 count of positive weights being equal to zero. Previously this would segfault when it attempted to insert the player into the queue, and with this change it appears to complete.