### PR TITLE
[Bug] fixing several minor bugs and associated with getting Hornet

### DIFF
--- a/hornet/include/Core/MemoryManager/MemoryManagerConf.hpp
+++ b/hornet/include/Core/MemoryManager/MemoryManagerConf.hpp
@@ -54,7 +54,7 @@ const size_t MIN_EDGES_PER_BLOCK = 1;
  * @brief number of edges for a **BlockArray**
  * @remark `EDGES_PER_BLOCKARRAY` must be a power of two
  */
-const size_t EDGES_PER_BLOCKARRAY = 1 << 18;
+const size_t EDGES_PER_BLOCKARRAY = 1 << 23;
 
 ///@brief Eanble B+Tree container for BitTree
 //#define B_PLUS_TREE

--- a/hornetsnest/include/Static/BreadthFirstSearch/TopDown2.cuh
+++ b/hornetsnest/include/Static/BreadthFirstSearch/TopDown2.cuh
@@ -59,6 +59,9 @@ public:
     bool validate() override;
 
     void set_parameters(vid_t source);
+
+    dist_t getLevels(){return current_level;}
+
 private:
     TwoLevelQueue<vid_t>        queue;
     load_balancing::BinarySearch load_balancing;

--- a/hornetsnest/test/BFSTest2.cu
+++ b/hornetsnest/test/BFSTest2.cu
@@ -25,8 +25,12 @@ int exec(int argc, char* argv[]) {
     BfsTopDown2 bfs_top_down(hornet_graph);
  
 	vid_t root = graph.max_out_degree_id();
+
 	if (argc==3)
 	  root = atoi(argv[2]);
+
+    std::cout << "My root is " << root << std::endl;
+
 
     bfs_top_down.set_parameters(root);
  
@@ -39,6 +43,8 @@ int exec(int argc, char* argv[]) {
     TM.stop();
     cudaProfilerStop();
     TM.print("TopDown2");
+
+    std::cout << "Number of levels is : " << bfs_top_down.getLevels() << std::endl;
 
     auto is_correct = bfs_top_down.validate();
     std::cout << (is_correct ? "\nCorrect <>\n\n" : "\n! Not Correct\n\n");

--- a/primitives/Operator++.i.cuh
+++ b/primitives/Operator++.i.cuh
@@ -664,7 +664,7 @@ void forAllEdgeVertexPairs(HornetClass&         hornet,
 
 //==============================================================================
 
-template<typename HornetClass, typename Operator, typename T>
+template<typename HornetClass, typename Operator>
 void forAllVertices(HornetClass&    hornet,
                     const vid_t*    vertex_array,
                     int             size,

--- a/primitives/Queue/TwoLevelQueue.cuh
+++ b/primitives/Queue/TwoLevelQueue.cuh
@@ -137,6 +137,10 @@ public:
      */
     int size() const noexcept;
 
+    int size_sync_in()  const noexcept;
+    int size_sync_out() const noexcept;
+
+
     /**
      * @warning the method is NOT sycnhronized
      */

--- a/primitives/Queue/TwoLevelQueue.i.cuh
+++ b/primitives/Queue/TwoLevelQueue.i.cuh
@@ -200,6 +200,23 @@ int TwoLevelQueue<T>::size() const noexcept {
 }
 
 template<typename T>
+int TwoLevelQueue<T>::size_sync_in() const noexcept {
+    int2 temp;
+    cuMemcpyToHost(_d_counters,temp);
+    return temp.x;
+}
+
+
+template<typename T>
+int TwoLevelQueue<T>::size_sync_out() const noexcept {
+    int2 temp;
+    cuMemcpyToHost(_d_counters,temp);
+
+    // printf ("(x, y)=(%d, %d)\n",temp.x, temp.y);
+    return temp.y;
+}
+
+template<typename T>
 int TwoLevelQueue<T>::output_size() const noexcept {
     return _h_counters.y;
 }


### PR DESCRIPTION
1) The default block array size was set to a small value and can cause Hornet to crash for large graphs. The default value will be become a runtime parameter in the future, but in this meantime this is for convenience.
2) One of the forAll primitives had an extra template parameter that caused compiler problems.
3) Unable to get the size of the active queue size without doing a swap of `curr` with `next`, despite there being cases when the active size is desirable without such a swap.
4) Add function to return the number of levels in the BFS.