### PR TITLE
Add simple usage check for hornet test executables.

### DIFF
--- a/hornet/test/BinarySearchTest.cu
+++ b/hornet/test/BinarySearchTest.cu
@@ -151,6 +151,11 @@ struct LL {
 int exec(int argc, char* argv[]) {
     using namespace graph;
 
+    if (argc < 2) {
+	std::cout << "Usage: lb_test <graph_file>" << std::endl;
+	return 1;
+    }
+
     GraphStd<int, int> graph1;
     graph1.read(argv[1]);
 

--- a/hornet/test/HornetDeleteTest.cu
+++ b/hornet/test/HornetDeleteTest.cu
@@ -78,6 +78,11 @@ int exec(int argc, char* argv[]) {
     using namespace graph::structure_prop;
     using namespace graph::parsing_prop;
 
+    if (argc < 3) {
+	std::cout << "Usage: hornet_delete_test <graph_file> <batch_size>" << std::endl;
+	return 1;
+    }
+
     graph::GraphStd<vert_t, vert_t> graph;
     graph.read(argv[1]);
     int batch_size = std::stoi(argv[2]);

--- a/hornet/test/HornetInsertTest.cu
+++ b/hornet/test/HornetInsertTest.cu
@@ -33,6 +33,11 @@ int exec(int argc, char* argv[]) {
     using namespace graph::structure_prop;
     using namespace graph::parsing_prop;
 
+    if (argc < 3) {
+	std::cout << "Usage: hornet_insert_test <graph_file> <batch_size>" << std::endl;
+	return 1;
+    }
+
     graph::GraphStd<vert_t, vert_t> graph;
     graph.read(argv[1]);
     int batch_size = std::stoi(argv[2]);

--- a/hornet/test/HornetInsertTestWeighted.cu
+++ b/hornet/test/HornetInsertTestWeighted.cu
@@ -31,6 +31,11 @@ int exec(int argc, char* argv[]) {
     using namespace graph::structure_prop;
     using namespace graph::parsing_prop;
 
+    if (argc < 3) {
+	std::cout << "Usage: hornet_insert_weighted_test <graph_file> <batch_size>" << std::endl;
+	return 1;
+    }
+
     graph::GraphStd<vert_t, vert_t> graph;
     graph.read(argv[1]);
     int batch_size = std::stoi(argv[2]);

--- a/hornet/test/HornetMultiGPUInsertTest.cu
+++ b/hornet/test/HornetMultiGPUInsertTest.cu
@@ -34,6 +34,11 @@ int exec(int argc, char* argv[]) {
     using namespace graph::structure_prop;
     using namespace graph::parsing_prop;
 
+    if (argc < 3) {
+	std::cout << "Usage: hornet_mgpu_insert_test <graph_file> <batch_size>" << std::endl;
+	return 1;
+    }
+
     graph::GraphStd<vert_t, vert_t> graph;
     graph.read(argv[1]);
     int batch_size = std::stoi(argv[2]);


### PR DESCRIPTION
Basic check of `argc` for the correct number of arguments before dereferencing `argv` in the `hornet/test` executables. This does not apply to `hornetsnest/test`, since those use a different command line parser.

Fixes #51.